### PR TITLE
raised action versions to v1

### DIFF
--- a/.github/workflows/release-version.yaml
+++ b/.github/workflows/release-version.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Create version releases
-        uses: climpr/semver-release@v0
+        uses: climpr/semver-release@v1
         with:
           update-type: ${{ github.event.inputs.update-type }}
           label: ${{ github.event.inputs.label }}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This action is used by calling it in a step as follows:
 
 ```yaml
 - name: Write module documentation
-  uses: climpr/document-bicep-module@v0
+  uses: climpr/document-bicep-module@v1
   with:
     root-path: bicep-modules
     module-name: name of module
@@ -93,7 +93,7 @@ jobs:
 
       - name: Get Bicep modules
         id: get-module-names
-        uses: climpr/get-bicep-modules@v0
+        uses: climpr/get-bicep-modules@v1
         with:
           root-path: ${{ env.root-path }}
           module-name: ${{ inputs.module-name }}
@@ -129,7 +129,7 @@ jobs:
           subscription-id: ${{ vars.SUBSCRIPTION_ID }}
 
       - name: Write module documentation
-        uses: climpr/document-bicep-module@v0
+        uses: climpr/document-bicep-module@v1
         with:
           root-path: ${{ env.root-path }}
           module-name: ${{ matrix.module-name }}

--- a/action.yaml
+++ b/action.yaml
@@ -36,7 +36,7 @@ runs:
         Write-Output "module-dir=$moduleDir" >> $env:GITHUB_OUTPUT
 
     - name: Install PS Modules
-      uses: climpr/install-psmodules@v0
+      uses: climpr/install-psmodules@v1
       with:
         modules: |
           Az.Accounts:3.0.0


### PR DESCRIPTION
internal testing succeeded. 

contains a soft dependency on get-bicep-module being raised to v1 before merging/releasing this action's v1 (readme file reference):
https://github.com/climpr/get-bicep-modules/pull/3

EDIT:
testing succeeded